### PR TITLE
Upgrade to nokogiri 1.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hide_and_seek (0.0.6)
+    hide_and_seek (0.0.7)
       rails (~> 4)
       redis
 
@@ -44,7 +44,7 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.4)
     builder (3.2.3)
-    combustion (0.5.5)
+    combustion (0.6.0)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
       thor (>= 0.14.6)
@@ -63,7 +63,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
-    nokogiri (1.7.0.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     rack (1.6.5)
     rack-test (0.6.3)
@@ -123,7 +123,7 @@ GEM
     sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.6)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -138,4 +138,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.14.4
+   1.14.6


### PR DESCRIPTION
USN-3235-1 - LIBXML2 VULNERABILITIES
Nokogiri is affected via its dependency libxml2.

CVE-2016-4448: Format string vulnerability in libxml2 allows attackers to have unspecified impact via format string specifiers in unknown vectors.

CVE-2016-4658: libxml2 allows remote attackers to execute arbitrary code or cause a denial of service (memory corruption) via a crafted XML document.

CVE-2016-5131: libxml2 allows remote attackers to cause a denial of service or possibly have unspecified other impact via vectors related to the XPointer range-to function.

Affected versions: All versions
Fixed versions: 1.7.1
Identifier: USN-3235-1
Solution: Upgrade to latest version
Sources: https://github.com/sparklemotion/nokogiri/issues/1615
http://people.canonical.com/~ubuntu-security/cve/2016/CVE-2016-4448.html
http://people.canonical.com/~ubuntu-security/cve/2016/CVE-2016-4658.html
http://people.canonical.com/~ubuntu-security/cve/2016/CVE-2016-5131.html

diff --git a/Gemfile b/Gemfile