### PR TITLE
Upgrade to nokogiri 1.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
-    nokogiri (1.7.1)
+    nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
     rack (1.6.5)
     rack-test (0.6.3)


### PR DESCRIPTION
Fixes the vulnerabilities mentioned below:

# USN-3271-1 - UPSTREAM LIBXSLT VULNERABILITIES
## CVE-2017-5029: The xsltAddTextString function in transform.c lacks a check for integer overflow during a size calculation, which allows a remote attacker to perform an out of bounds memory write via a crafted HTML page.
## CVE-2016-1683: numbers.c in libxslt mishandles namespace nodes, which allows remote attackers to cause a denial of service (out-of-bounds heap memory access) or possibly have unspecified other impact via a crafted document.
## CVE-2016-1841: libxslt allows remote attackers to execute arbitrary code or cause a denial of service (memory corruption) via a crafted web site.
Fixed versions: 1.7.2
Identifier: USN-3271-1
Solution: Upgrade to latest version.
Sources: https://github.com/sparklemotion/nokogiri/issues/1634 
http://people.canonical.com/~ubuntu-security/cve/2017/CVE-2017-5029.html 
http://people.canonical.com/~ubuntu-security/cve/2016/CVE-2016-4738.html 